### PR TITLE
add batch time out config

### DIFF
--- a/gokafka/kafka.go
+++ b/gokafka/kafka.go
@@ -6,6 +6,7 @@ import (
 	"github.com/segmentio/kafka-go/snappy"
 	"github.com/sunmi-OS/gocore/viper"
 	"sync"
+	"time"
 )
 
 
@@ -43,6 +44,7 @@ func (p *Producer) newProducer(topic string)  {
 		Topic:        topic,
 		RequiredAcks: viper.C.GetInt("kafkaClient.acks"),
 		Async:        viper.C.GetBool("kafkaClient.async"),
+		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("batchTimeout")),
 	}
 
 	if viper.C.GetBool("kafkaClient.compression") == true {

--- a/gokafka/kafka.go
+++ b/gokafka/kafka.go
@@ -44,7 +44,7 @@ func (p *Producer) newProducer(topic string)  {
 		Topic:        topic,
 		RequiredAcks: viper.C.GetInt("kafkaClient.acks"),
 		Async:        viper.C.GetBool("kafkaClient.async"),
-		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("batchTimeout")),
+		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("kafkaClient.batchTimeout")),
 	}
 
 	if viper.C.GetBool("kafkaClient.compression") == true {


### PR DESCRIPTION
添加了重要kafka producer 配置参数 batch time out，通常可以增加该值来提高producer吞吐量。考虑到参数过多，接下来将引入默认配置参数。