### PR TITLE
 add batch time out config

### DIFF
--- a/encryption/aes/aes.go
+++ b/encryption/aes/aes.go
@@ -4,10 +4,79 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"strings"
 )
+
+// Encrypt using random iv parameter and cbc mode
+// Never panic, only possible to return an error
+func EncryptUseCBCWithDefaultProtocol(plainText, key []byte) ([]byte, error) {
+	iv := make([]byte, 16)
+	//random iv param
+	_, err := rand.Read(iv)
+	if err != nil {
+		return nil, err
+	}
+	cipherText, err := EncryptUseCBC(plainText, key, iv)
+	if err != nil {
+		return nil, err
+	}
+
+	//Put the iv parameter in the head of the cipher text
+	result := append(iv, cipherText...)
+	return result, err
+}
+
+// Encrypt using cbc mode
+// When iv length does not equal block size, it will panic
+func EncryptUseCBC(plainText, key, iv []byte) ([]byte, error) {
+	blockKey, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := blockKey.BlockSize()
+	// do padding
+	fixedPlainText := PKCS5Padding(plainText, blockSize)
+	encryptTool := cipher.NewCBCEncrypter(blockKey, iv)
+	cipherText := make([]byte, len(fixedPlainText))
+	// do final
+	encryptTool.CryptBlocks(cipherText, fixedPlainText)
+	return cipherText, nil
+}
+
+// Decrypt using cbc mode
+// There are two kinds of panic that may occur:
+// 1. When iv length do not equal block size
+// 2. When key does not match the cipher text, and it always happens when do unpadding
+func DecryptUseCBC(cipherText, key []byte, iv []byte) ([]byte, error) {
+	blockKey, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := blockKey.BlockSize()
+	if len(cipherText) % blockSize != 0 {
+		return nil, errors.New("cipher text is not an integral multiple of the block size")
+	}
+	decryptTool := cipher.NewCBCDecrypter(blockKey, iv)
+	// CryptBlocks can work in-place if the two arguments are the same.
+	decryptTool.CryptBlocks(cipherText, cipherText)
+	return PKCS5UnPadding(cipherText), nil
+}
+
+// Decrypt using given iv parameter and cbc mode
+// When key does not match the cipher text, it will panic
+func DecryptUseCBCWithDefaultProtocol(cipherText, key []byte) ([]byte, error) {
+	if len(cipherText) < 16 {
+		return nil, errors.New("decrypt excepted iv parameter")
+	}
+	plainText, err := DecryptUseCBC(cipherText[16:], key, cipherText[:16])
+	if err != nil {
+		return nil, err
+	}
+	return plainText, nil
+}
 
 func getKey(key string) []byte {
 	keyLen := len(key)

--- a/gokafka/kafka.go
+++ b/gokafka/kafka.go
@@ -6,6 +6,7 @@ import (
 	"github.com/segmentio/kafka-go/snappy"
 	"github.com/sunmi-OS/gocore/viper"
 	"sync"
+	"time"
 )
 
 
@@ -43,6 +44,7 @@ func (p *Producer) newProducer(topic string)  {
 		Topic:        topic,
 		RequiredAcks: viper.C.GetInt("kafkaClient.acks"),
 		Async:        viper.C.GetBool("kafkaClient.async"),
+		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("batchTimeout")),
 	}
 
 	if viper.C.GetBool("kafkaClient.compression") == true {

--- a/gokafka/kafka.go
+++ b/gokafka/kafka.go
@@ -44,7 +44,7 @@ func (p *Producer) newProducer(topic string)  {
 		Topic:        topic,
 		RequiredAcks: viper.C.GetInt("kafkaClient.acks"),
 		Async:        viper.C.GetBool("kafkaClient.async"),
-		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("batchTimeout")),
+		BatchTimeout: time.Millisecond * time.Duration(viper.C.GetInt("kafkaClient.batchTimeout")),
 	}
 
 	if viper.C.GetBool("kafkaClient.compression") == true {


### PR DESCRIPTION
添加了重要kafka producer 配置参数 batch time out，通常可以增加该值来提高producer吞吐量。考虑到参数过多，接下来将引入默认配置参数。