### PR TITLE
let the kafka be more useful

### DIFF
--- a/gokafka/kafka.go
+++ b/gokafka/kafka.go
@@ -21,7 +21,7 @@ var producerMap sync.Map
 func LoadProducerByTopic(topic string) *Producer {
 	value, _ := producerMap.Load(topic)
 	if value == nil {
-		return nil
+		return Init(topic)
 	} else {
 		return value.(*Producer)
 	}


### PR DESCRIPTION
这样只有需要用到的producer 才动态去初始化，且 兼容老版本