### PR TITLE
fix when go version <= 1.14, xlog's bug that Lmsgprefix not declared

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -24,8 +24,8 @@ func (g *GinEngine) CORS() gin.HandlerFunc {
 		}
 		if origin != "" {
 			c.Header("Access-Control-Allow-Origin", origin)
-			c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, X-CSRF-Token, authorization, sign, appid, ts")
-			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, HEAD")
+			c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, X-CSRF-Token, Authorization, Token, Session")
+			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS")
 			c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type")
 			c.Header("Access-Control-Max-Age", "172800")
 			c.Header("Access-Control-Allow-Credentials", "true")

--- a/xlog/debug_logger.go
+++ b/xlog/debug_logger.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -24,5 +27,10 @@ func (i *DebugLogger) logOut(format *string, v ...interface{}) {
 }
 
 func (i *DebugLogger) new() {
-	i.logger = log.New(os.Stdout, "[DEBUG] >> ", log.Lmsgprefix|log.Lshortfile|log.Lmicroseconds|log.Ldate)
+	version, _ := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	if version >= 14 {
+		i.logger = log.New(os.Stdout, "[DEBUG] >> ", 64|log.Lshortfile|log.Ldate|log.Lmicroseconds)
+		return
+	}
+	i.logger = log.New(os.Stdout, "[DEBUG] ", log.Lshortfile|log.Ldate|log.Lmicroseconds)
 }

--- a/xlog/error_logger.go
+++ b/xlog/error_logger.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -26,5 +29,10 @@ func (e *ErrorLogger) logOut(format *string, v ...interface{}) {
 }
 
 func (e *ErrorLogger) new() {
-	e.logger = log.New(os.Stderr, "[ERROR] >> ", log.Lmsgprefix|log.Lshortfile|log.Lmicroseconds|log.Ldate)
+	version, _ := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	if version >= 14 {
+		e.logger = log.New(os.Stdout, "[ERROR] >> ", 64|log.Lshortfile|log.Ldate|log.Lmicroseconds)
+		return
+	}
+	e.logger = log.New(os.Stdout, "[ERROR] ", log.Lshortfile|log.Ldate|log.Lmicroseconds)
 }

--- a/xlog/info_logger.go
+++ b/xlog/info_logger.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -24,5 +27,10 @@ func (i *InfoLogger) logOut(format *string, v ...interface{}) {
 }
 
 func (i *InfoLogger) new() {
-	i.logger = log.New(os.Stdout, "[INFO] >> ", log.Lmsgprefix|log.Lshortfile|log.Lmicroseconds|log.Ldate)
+	version, _ := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	if version >= 14 {
+		i.logger = log.New(os.Stdout, "[INFO] >> ", 64|log.Lshortfile|log.Ldate|log.Lmicroseconds)
+		return
+	}
+	i.logger = log.New(os.Stdout, "[INFO] ", log.Lshortfile|log.Ldate|log.Lmicroseconds)
 }

--- a/xlog/warn_logger.go
+++ b/xlog/warn_logger.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -24,5 +27,10 @@ func (i *WarnLogger) logOut(format *string, v ...interface{}) {
 }
 
 func (i *WarnLogger) new() {
-	i.logger = log.New(os.Stderr, "[WARN] >> ", log.Lmsgprefix|log.Lshortfile|log.Lmicroseconds|log.Ldate)
+	version, _ := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	if version >= 14 {
+		i.logger = log.New(os.Stdout, "[WARN] >> ", 64|log.Lshortfile|log.Ldate|log.Lmicroseconds)
+		return
+	}
+	i.logger = log.New(os.Stdout, "[WARN] ", log.Lshortfile|log.Ldate|log.Lmicroseconds)
 }


### PR DESCRIPTION
fix when go version <= 1.14, xlog's bug that Lmsgprefix not declared