### PR TITLE
Added support for concurrent reuse of coroutines

### DIFF
--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -1,0 +1,116 @@
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
+// A group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error. use WithContext instead.
+type Group interface {
+	// Go calls the given function in a new goroutine.
+	//
+	// The first call to return a non-nil error cancels the group; its error will be
+	// returned by Wait.
+	Go(fn func(ctx context.Context) error)
+
+	// GOMAXPROCS set max goroutine to work.
+	GOMAXPROCS(n int)
+
+	// Wait blocks until all function calls from the Go method have returned, then
+	// returns the first non-nil error (if any) from them.
+	Wait() error
+}
+
+type group struct {
+	err     error
+	wg      sync.WaitGroup
+	errOnce sync.Once
+
+	workOnce sync.Once
+	ch       chan func(ctx context.Context) error
+	cache    []func(ctx context.Context) error
+
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+}
+
+// WithContext returns a new group with a canceled Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs first.
+func WithContext(ctx context.Context) Group {
+	ctx, cancel := context.WithCancelCause(ctx)
+	return &group{ctx: ctx, cancel: cancel}
+}
+
+func (g *group) GOMAXPROCS(n int) {
+	if n <= 0 {
+		return
+	}
+	g.workOnce.Do(func() {
+		g.ch = make(chan func(context.Context) error, n)
+		for i := 0; i < n; i++ {
+			go func() {
+				for fn := range g.ch {
+					g.do(fn)
+				}
+			}()
+		}
+	})
+}
+
+func (g *group) Go(fn func(ctx context.Context) error) {
+	g.wg.Add(1)
+
+	if g.ch != nil {
+		select {
+		case g.ch <- fn:
+		default:
+			g.cache = append(g.cache, fn)
+		}
+		return
+	}
+
+	go g.do(fn)
+}
+
+func (g *group) Wait() error {
+	defer func() {
+		g.cancel(g.err)
+		if g.ch != nil {
+			close(g.ch) // let all receiver exit
+		}
+	}()
+
+	if g.ch != nil {
+		for _, fn := range g.cache {
+			g.ch <- fn
+		}
+	}
+	g.wg.Wait()
+
+	return g.err
+}
+
+func (g *group) do(fn func(ctx context.Context) error) {
+	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("errgroup panic recovered: %+v\n%s", r, string(debug.Stack()))
+		}
+		if err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				g.cancel(err)
+			})
+		}
+		g.wg.Done()
+	}()
+	err = fn(g.ctx)
+}

--- a/errgroup/errgroup_test.go
+++ b/errgroup/errgroup_test.go
@@ -1,0 +1,241 @@
+package errgroup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormal(t *testing.T) {
+	m := make(map[int]int)
+	for i := 0; i < 4; i++ {
+		m[i] = i
+	}
+	eg := WithContext(context.Background())
+	eg.Go(func(context.Context) (err error) {
+		m[1]++
+		return
+	})
+	eg.Go(func(context.Context) (err error) {
+		m[2]++
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		t.Log(err)
+	}
+	t.Log(m)
+}
+
+func sleep1s(context.Context) error {
+	time.Sleep(time.Second)
+	return nil
+}
+
+func TestGOMAXPROCS(t *testing.T) {
+	ctx := context.Background()
+
+	// 没有并发数限制
+	eg := WithContext(ctx)
+	now := time.Now()
+	eg.Go(sleep1s)
+	eg.Go(sleep1s)
+	eg.Go(sleep1s)
+	eg.Go(sleep1s)
+	err := eg.Wait()
+	assert.Nil(t, err)
+	sec := math.Round(time.Since(now).Seconds())
+	if sec != 1 {
+		t.FailNow()
+	}
+
+	// 限制并发数
+	eg2 := WithContext(ctx)
+	eg2.GOMAXPROCS(2)
+	now = time.Now()
+	eg2.Go(sleep1s)
+	eg2.Go(sleep1s)
+	eg2.Go(sleep1s)
+	eg2.Go(sleep1s)
+	err = eg2.Wait()
+	assert.Nil(t, err)
+	sec = math.Round(time.Since(now).Seconds())
+	if sec != 2 {
+		t.FailNow()
+	}
+
+	// context canceled
+	eg3 := WithContext(ctx)
+	eg3.GOMAXPROCS(2)
+	eg3.Go(func(context.Context) error {
+		return errors.New("error for testing errgroup context")
+	})
+	eg3.Go(func(ctx context.Context) error {
+		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			t.Log("caused by", context.Cause(ctx))
+		default:
+		}
+		return nil
+	})
+	err = eg3.Wait()
+	assert.NotNil(t, err)
+	t.Log(err)
+}
+
+func TestRecover(t *testing.T) {
+	eg := WithContext(context.Background())
+	eg.Go(func(context.Context) (err error) {
+		panic("oh my god!")
+	})
+	if err := eg.Wait(); err != nil {
+		t.Log(err)
+		return
+	}
+	t.FailNow()
+}
+
+var (
+	Web   = fakeSearch("web")
+	Image = fakeSearch("image")
+	Video = fakeSearch("video")
+)
+
+type (
+	Result string
+	Search func(ctx context.Context, query string) (Result, error)
+)
+
+func fakeSearch(kind string) Search {
+	return func(_ context.Context, query string) (Result, error) {
+		return Result(fmt.Sprintf("%s result for %q", kind, query)), nil
+	}
+}
+
+// JustErrors illustrates the use of a Group in place of a sync.WaitGroup to
+// simplify goroutine counting and error handling. This example is derived from
+// the sync.WaitGroup example at https://golang.org/pkg/sync/#example_WaitGroup.
+func ExampleGroup_justErrors() {
+	eg := WithContext(context.Background())
+	urls := []string{
+		"http://www.golang.org/",
+		"http://www.google.com/",
+		"http://www.somestupidname.com/",
+	}
+	for _, _url := range urls {
+		// Launch a goroutine to fetch the URL.
+		url := _url // https://golang.org/doc/faq#closures_and_goroutines
+		eg.Go(func(context.Context) error {
+			// Fetch the URL.
+			resp, err := http.Get(url)
+			if err == nil {
+				resp.Body.Close()
+			}
+			return err
+		})
+	}
+	// Wait for all HTTP fetches to complete.
+	if err := eg.Wait(); err == nil {
+		fmt.Println("Successfully fetched all URLs.")
+	}
+}
+
+// Parallel illustrates the use of a Group for synchronizing a simple parallel
+// task: the "Google Search 2.0" function from
+// https://talks.golang.org/2012/concurrency.slide#46, augmented with a Context
+// and error-handling.
+func ExampleGroup_parallel() {
+	Google := func(ctx context.Context, query string) ([]Result, error) {
+		eg := WithContext(context.Background())
+
+		searches := []Search{Web, Image, Video}
+		results := make([]Result, len(searches))
+		for _i, _search := range searches {
+			i, search := _i, _search // https://golang.org/doc/faq#closures_and_goroutines
+			eg.Go(func(context.Context) error {
+				result, err := search(ctx, query)
+				if err == nil {
+					results[i] = result
+				}
+				return err
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return nil, err
+		}
+		return results, nil
+	}
+
+	results, err := Google(context.Background(), "golang")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+
+	// Output:
+	// web result for "golang"
+	// image result for "golang"
+	// video result for "golang"
+}
+
+func TestZeroGroup(t *testing.T) {
+	err1 := errors.New("errgroup_test: 1")
+	err2 := errors.New("errgroup_test: 2")
+
+	cases := []struct {
+		errs []error
+	}{
+		{errs: []error{}},
+		{errs: []error{nil}},
+		{errs: []error{err1}},
+		{errs: []error{err1, nil}},
+		{errs: []error{err1, nil, err2}},
+	}
+
+	for _, tc := range cases {
+		eg := WithContext(context.Background())
+
+		var firstErr error
+		for i, err := range tc.errs {
+			err := err
+			eg.Go(func(context.Context) error { return err })
+
+			if firstErr == nil && err != nil {
+				firstErr = err
+			}
+
+			if gErr := eg.Wait(); gErr != firstErr {
+				t.Errorf("after g.Go(func() error { return err }) for err in %v\n"+
+					"g.Wait() = %v; want %v", tc.errs[:i+1], err, firstErr)
+			}
+		}
+	}
+}
+
+func TestWithCancel(t *testing.T) {
+	eg := WithContext(context.Background())
+	eg.Go(func(ctx context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		return fmt.Errorf("boom")
+	})
+	var doneErr error
+	eg.Go(func(ctx context.Context) error {
+		<-ctx.Done()
+		doneErr = ctx.Err()
+		return doneErr
+	})
+	_ = eg.Wait()
+	if doneErr != context.Canceled {
+		t.Error("error should be Canceled")
+	}
+}

--- a/errgroup/poolgroup.go
+++ b/errgroup/poolgroup.go
@@ -1,0 +1,68 @@
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+
+	"github.com/sunmi-OS/gocore/v2/worker"
+)
+
+type poolgroup struct {
+	wg   sync.WaitGroup
+	pool worker.Pool
+
+	err  error
+	once sync.Once
+
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+}
+
+// WithPoolContext returns a new group with a canceled Context derived from ctx which use work pool.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs first.
+func WithPoolContext(ctx context.Context, pool worker.Pool) Group {
+	ctx, cancel := context.WithCancelCause(ctx)
+
+	return &poolgroup{
+		pool:   pool,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (pg *poolgroup) Go(fn func(ctx context.Context) error) {
+	pg.wg.Add(1)
+	pg.do(fn)
+}
+
+func (pg *poolgroup) GOMAXPROCS(_ int) {}
+
+func (pg *poolgroup) Wait() error {
+	defer pg.cancel(pg.err)
+	pg.wg.Wait()
+
+	return pg.err
+}
+
+func (pg *poolgroup) do(fn func(ctx context.Context) error) {
+	pg.pool.Go(pg.ctx, func(ctx context.Context) {
+		var err error
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("errgroup panic recovered: %+v\n%s", r, string(debug.Stack()))
+			}
+			if err != nil {
+				pg.once.Do(func() {
+					pg.err = err
+					pg.cancel(err)
+				})
+			}
+			pg.wg.Done()
+		}()
+		err = fn(ctx)
+	})
+}

--- a/errgroup/poolgroup_test.go
+++ b/errgroup/poolgroup_test.go
@@ -1,0 +1,166 @@
+package errgroup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sunmi-OS/gocore/v2/worker"
+)
+
+func TestPoolNormal(t *testing.T) {
+	m := make(map[int]int)
+	for i := 0; i < 4; i++ {
+		m[i] = i
+	}
+	eg := WithPoolContext(context.Background(), worker.P())
+	eg.Go(func(context.Context) (err error) {
+		m[1]++
+		return
+	})
+	eg.Go(func(context.Context) (err error) {
+		m[2]++
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		t.Log(err)
+	}
+	t.Log(m)
+}
+
+func TestPoolRecover(t *testing.T) {
+	eg := WithPoolContext(context.Background(), worker.P())
+	eg.Go(func(context.Context) (err error) {
+		panic("oh my god!")
+	})
+	if err := eg.Wait(); err != nil {
+		t.Log(err)
+		return
+	}
+	t.FailNow()
+}
+
+// JustErrors illustrates the use of a Group in place of a sync.WaitGroup to
+// simplify goroutine counting and error handling. This example is derived from
+// the sync.WaitGroup example at https://golang.org/pkg/sync/#example_WaitGroup.
+func ExamplePoolGroup_justErrors() {
+	eg := WithPoolContext(context.Background(), worker.P())
+	urls := []string{
+		"http://www.golang.org/",
+		"http://www.google.com/",
+		"http://www.somestupidname.com/",
+	}
+	for _, _url := range urls {
+		// Launch a goroutine to fetch the URL.
+		url := _url // https://golang.org/doc/faq#closures_and_goroutines
+		eg.Go(func(context.Context) error {
+			// Fetch the URL.
+			resp, err := http.Get(url)
+			if err == nil {
+				resp.Body.Close()
+			}
+			return err
+		})
+	}
+	// Wait for all HTTP fetches to complete.
+	if err := eg.Wait(); err == nil {
+		fmt.Println("Successfully fetched all URLs.")
+	}
+}
+
+// Parallel illustrates the use of a Group for synchronizing a simple parallel
+// task: the "Google Search 2.0" function from
+// https://talks.golang.org/2012/concurrency.slide#46, augmented with a Context
+// and error-handling.
+func ExamplePoolGroup_parallel() {
+	Google := func(ctx context.Context, query string) ([]Result, error) {
+		eg := WithPoolContext(ctx, worker.P())
+
+		searches := []Search{Web, Image, Video}
+		results := make([]Result, len(searches))
+		for _i, _search := range searches {
+			i, search := _i, _search // https://golang.org/doc/faq#closures_and_goroutines
+			eg.Go(func(context.Context) error {
+				result, err := search(ctx, query)
+				if err == nil {
+					results[i] = result
+				}
+				return err
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return nil, err
+		}
+		return results, nil
+	}
+
+	results, err := Google(context.Background(), "golang")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	for _, result := range results {
+		fmt.Println(result)
+	}
+
+	// Output:
+	// web result for "golang"
+	// image result for "golang"
+	// video result for "golang"
+}
+
+func TestPoolZeroGroup(t *testing.T) {
+	err1 := errors.New("errgroup_test: 1")
+	err2 := errors.New("errgroup_test: 2")
+
+	cases := []struct {
+		errs []error
+	}{
+		{errs: []error{}},
+		{errs: []error{nil}},
+		{errs: []error{err1}},
+		{errs: []error{err1, nil}},
+		{errs: []error{err1, nil, err2}},
+	}
+
+	for _, tc := range cases {
+		eg := WithPoolContext(context.Background(), worker.P())
+
+		var firstErr error
+		for i, err := range tc.errs {
+			err := err
+			eg.Go(func(context.Context) error { return err })
+
+			if firstErr == nil && err != nil {
+				firstErr = err
+			}
+
+			if gErr := eg.Wait(); gErr != firstErr {
+				t.Errorf("after g.Go(func() error { return err }) for err in %v\n"+
+					"g.Wait() = %v; want %v", tc.errs[:i+1], err, firstErr)
+			}
+		}
+	}
+}
+
+func TestPoolWithCancel(t *testing.T) {
+	eg := WithPoolContext(context.Background(), worker.P())
+	eg.Go(func(ctx context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		return fmt.Errorf("boom")
+	})
+	var doneErr error
+	eg.Go(func(ctx context.Context) error {
+		<-ctx.Done()
+		doneErr = ctx.Err()
+		return doneErr
+	})
+	_ = eg.Wait()
+	if doneErr != context.Canceled {
+		t.Error("error should be Canceled")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.6.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80
 	google.golang.org/grpc v1.62.0
 	google.golang.org/protobuf v1.33.0
@@ -138,7 +139,6 @@ require (
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/linklist/doublylinklist.go
+++ b/linklist/doublylinklist.go
@@ -1,0 +1,390 @@
+package linklist
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// DoublyLinkList 双向链表(并发安全)
+type DoublyLinkList[T comparable] struct {
+	first *element[T]
+	last  *element[T]
+	size  int
+	mutex sync.RWMutex
+}
+
+type element[T comparable] struct {
+	value T
+	prev  *element[T]
+	next  *element[T]
+}
+
+// New 初始化一个链表
+func New[T comparable](values ...T) *DoublyLinkList[T] {
+	list := &DoublyLinkList[T]{}
+	if len(values) > 0 {
+		list.appendWithoutLock(values...)
+	}
+	return list
+}
+
+// Append 向链表尾部追加值
+func (list *DoublyLinkList[T]) Append(values ...T) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	list.appendWithoutLock(values...)
+}
+
+// appendWithoutLock 向链表尾部追加值(不持有锁)
+func (list *DoublyLinkList[T]) appendWithoutLock(values ...T) {
+	for _, value := range values {
+		newElement := &element[T]{value: value, prev: list.last}
+		if list.size == 0 {
+			list.first = newElement
+			list.last = newElement
+		} else {
+			list.last.next = newElement
+			list.last = newElement
+		}
+		list.size++
+	}
+}
+
+// Prepend 向链表头部追加值
+func (list *DoublyLinkList[T]) Prepend(values ...T) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	// in reverse to keep passed order i.e. ["c","d"] -> Prepend(["a","b"]) -> ["a","b","c",d"]
+	for v := len(values) - 1; v >= 0; v-- {
+		newElement := &element[T]{value: values[v], next: list.first}
+		if list.size == 0 {
+			list.first = newElement
+			list.last = newElement
+		} else {
+			list.first.prev = newElement
+			list.first = newElement
+		}
+		list.size++
+	}
+}
+
+// Get 获取指定索引位置元素的值
+func (list *DoublyLinkList[T]) Get(index int) (T, bool) {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	if !list.withinRange(index) {
+		var t T
+		return t, false
+	}
+
+	e := list.getElement(index)
+	return e.value, true
+}
+
+// Remove 移除指定索引位置的元素并返回该元素的值
+func (list *DoublyLinkList[T]) Remove(index int) (T, bool) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	var value T
+	if !list.withinRange(index) {
+		return value, false
+	}
+
+	e := list.getElement(index)
+	value = e.value
+	list.deleteElement(e)
+
+	return value, true
+}
+
+// Each 遍历操作
+func (list *DoublyLinkList[T]) Each(fn func(index int, value T)) {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	for i, e := 0, list.first; e != nil; i, e = i+1, e.next {
+		fn(i, e.value)
+	}
+}
+
+// Map 根据指定条件，返回一个新链表
+func (list *DoublyLinkList[T]) Map(fn func(index int, value T) T) *DoublyLinkList[T] {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	newList := &DoublyLinkList[T]{}
+	for i, e := 0, list.first; e != nil; i, e = i+1, e.next {
+		newList.Append(fn(i, e.value))
+	}
+	return newList
+}
+
+// Filter 过滤出指定条件的元素，移除并返回包含的值
+func (list *DoublyLinkList[T]) Filter(fn func(index int, value T) bool) []T {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	var elements []*element[T]
+	for i, e := 0, list.first; e != nil; i, e = i+1, e.next {
+		if fn(i, e.value) {
+			elements = append(elements, e)
+		}
+	}
+
+	values := make([]T, 0, len(elements))
+	for _, e := range elements {
+		values = append(values, e.value)
+		list.deleteElement(e)
+	}
+	return values
+}
+
+// Contains 返回链表中是否包含指定值中的一个
+func (list *DoublyLinkList[T]) Contains(values ...T) bool {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	if len(values) == 0 {
+		return true
+	}
+	if list.size == 0 {
+		return false
+	}
+	for _, value := range values {
+		found := false
+		for e := list.first; e != nil; e = e.next {
+			if e.value == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Values 返回链表所有元素的值
+func (list *DoublyLinkList[T]) Values() []T {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	return list.valuesWithoutLock()
+}
+
+// valuesWithoutLock 返回链表所有元素的值(不持有锁)
+func (list *DoublyLinkList[T]) valuesWithoutLock() []T {
+	values := make([]T, 0, list.size)
+	for e := list.first; e != nil; e = e.next {
+		values = append(values, e.value)
+	}
+	return values
+}
+
+// IndexOf 返回指定值在链表中的索引，-1表示不存在
+func (list *DoublyLinkList[T]) IndexOf(value T) int {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	if list.size == 0 {
+		return -1
+	}
+	for index, e := range list.Values() {
+		if e == value {
+			return index
+		}
+	}
+	return -1
+}
+
+// Empty 返回链表是否为空
+func (list *DoublyLinkList[T]) Empty() bool {
+	return list.size == 0
+}
+
+// Size 返回链表的大小
+func (list *DoublyLinkList[T]) Size() int {
+	return list.size
+}
+
+// Clear 清空链表
+func (list *DoublyLinkList[T]) Clear() {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	list.clearWithoutLock()
+}
+
+// clearWithoutLock 清空链表(不持有锁)
+func (list *DoublyLinkList[T]) clearWithoutLock() {
+	list.size = 0
+	list.first = nil
+	list.last = nil
+}
+
+// Sort 将链表中元素值排序
+func (list *DoublyLinkList[T]) Sort(comparator func(x, y T) int) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	if list.size < 2 {
+		return
+	}
+
+	values := list.valuesWithoutLock()
+	slices.SortFunc(values, comparator)
+
+	list.clearWithoutLock()
+	list.appendWithoutLock(values...)
+}
+
+// Swap 交换链表中两个指定索引的元素
+func (list *DoublyLinkList[T]) Swap(i, j int) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	if list.withinRange(i) && list.withinRange(j) && i != j {
+		var element1, element2 *element[T]
+		for e, currentElement := 0, list.first; element1 == nil || element2 == nil; e, currentElement = e+1, currentElement.next {
+			switch e {
+			case i:
+				element1 = currentElement
+			case j:
+				element2 = currentElement
+			}
+		}
+		element1.value, element2.value = element2.value, element1.value
+	}
+}
+
+// Insert 在链表的指定索引位置插入值
+func (list *DoublyLinkList[T]) Insert(index int, values ...T) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	if !list.withinRange(index) {
+		// Append
+		if index == list.size {
+			list.appendWithoutLock(values...)
+		}
+		return
+	}
+
+	var beforeElement *element[T]
+	var foundElement *element[T]
+	// determine traversal direction, last to first or first to last
+	if list.size-index < index {
+		foundElement = list.last
+		beforeElement = list.last.prev
+		for e := list.size - 1; e != index; e, foundElement = e-1, foundElement.prev {
+			beforeElement = beforeElement.prev
+		}
+	} else {
+		foundElement = list.first
+		for e := 0; e != index; e, foundElement = e+1, foundElement.next {
+			beforeElement = foundElement
+		}
+	}
+
+	if foundElement == list.first {
+		oldNextElement := list.first
+		for i, value := range values {
+			newElement := &element[T]{value: value}
+			if i == 0 {
+				list.first = newElement
+			} else {
+				newElement.prev = beforeElement
+				beforeElement.next = newElement
+			}
+			beforeElement = newElement
+		}
+		oldNextElement.prev = beforeElement
+		beforeElement.next = oldNextElement
+	} else {
+		oldNextElement := beforeElement.next
+		for _, value := range values {
+			newElement := &element[T]{value: value}
+			newElement.prev = beforeElement
+			beforeElement.next = newElement
+			beforeElement = newElement
+		}
+		oldNextElement.prev = beforeElement
+		beforeElement.next = oldNextElement
+	}
+
+	list.size += len(values)
+}
+
+// Set 设置链表指定索引位置索引的值
+func (list *DoublyLinkList[T]) Set(index int, value T) {
+	list.mutex.Lock()
+	defer list.mutex.Unlock()
+
+	if !list.withinRange(index) {
+		// Append
+		if index == list.size {
+			list.appendWithoutLock(value)
+		}
+		return
+	}
+
+	list.getElement(index).value = value
+}
+
+// String 实现 Stringer Interface
+func (list *DoublyLinkList[T]) String() string {
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
+
+	str := "DoublyLinkList\n"
+	values := make([]string, 0, list.size)
+	for e := list.first; e != nil; e = e.next {
+		values = append(values, fmt.Sprintf("%v", e.value))
+	}
+	str += strings.Join(values, ", ")
+	return str
+}
+
+func (list *DoublyLinkList[T]) withinRange(index int) bool {
+	return index >= 0 && index < list.size
+}
+
+func (list *DoublyLinkList[T]) getElement(index int) *element[T] {
+	// determine traveral direction, last to first or first to last
+	if list.size-index < index {
+		e := list.last
+		for i := list.size - 1; i != index; i, e = i-1, e.prev {
+		}
+		return e
+	}
+
+	e := list.first
+	for i := 0; i != index; i, e = i+1, e.next {
+	}
+	return e
+}
+
+func (list *DoublyLinkList[T]) deleteElement(e *element[T]) {
+	if e == list.first {
+		list.first = e.next
+	}
+	if e == list.last {
+		list.last = e.prev
+	}
+	if e.prev != nil {
+		e.prev.next = e.next
+	}
+	if e.next != nil {
+		e.next.prev = e.prev
+	}
+	e = nil
+
+	list.size--
+}

--- a/linklist/doublylinklist_test.go
+++ b/linklist/doublylinklist_test.go
@@ -1,0 +1,459 @@
+package linklist
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	list1 := New[int]()
+	if actualValue := list1.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+
+	list2 := New[int](1, 2)
+	if actualValue := list2.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := list2.Get(0); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+	if actualValue, ok := list2.Get(1); actualValue != 2 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := list2.Get(2); actualValue != 0 || ok {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+}
+
+func TestAdd(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	if actualValue := list.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := list.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := list.Get(2); actualValue != "c" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "c")
+	}
+}
+
+func TestAppendAndPrepend(t *testing.T) {
+	list := New[string]()
+	list.Append("b")
+	list.Prepend("a")
+	list.Append("c")
+	if actualValue := list.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := list.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := list.Get(0); actualValue != "a" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "c")
+	}
+	if actualValue, ok := list.Get(1); actualValue != "b" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "c")
+	}
+	if actualValue, ok := list.Get(2); actualValue != "c" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "c")
+	}
+}
+
+func TestGet(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	if actualValue, ok := list.Get(0); actualValue != "a" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "a")
+	}
+	if actualValue, ok := list.Get(1); actualValue != "b" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "b")
+	}
+	if actualValue, ok := list.Get(2); actualValue != "c" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "c")
+	}
+	if actualValue, ok := list.Get(3); actualValue != "" || ok {
+		t.Errorf("Got %v expected %v", actualValue, "")
+	}
+	list.Remove(0)
+	if actualValue, ok := list.Get(0); actualValue != "b" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "b")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	list.Remove(2)
+	if actualValue, ok := list.Get(2); actualValue != "" || ok {
+		t.Errorf("Got %v expected %v", actualValue, "")
+	}
+	list.Remove(1)
+	list.Remove(0)
+	list.Remove(0) // no effect
+	if actualValue := list.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := list.Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+}
+
+func TestPop(t *testing.T) {
+	list := New[string]()
+	list.Append("a", "b", "c")
+	v, ok := list.Remove(0)
+	assert.True(t, ok)
+	assert.Equal(t, "a", v)
+	assert.Equal(t, 2, list.Size())
+	v, ok = list.Remove(0)
+	assert.True(t, ok)
+	assert.Equal(t, "b", v)
+	assert.Equal(t, 1, list.Size())
+	v, ok = list.Remove(0)
+	assert.True(t, ok)
+	assert.Equal(t, "c", v)
+	assert.Equal(t, 0, list.Size())
+}
+
+func TestEach(t *testing.T) {
+	list := New[string]()
+	list.Append("a", "b", "c")
+	list.Each(func(index int, value string) {
+		switch index {
+		case 0:
+			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 1:
+			if actualValue, expectedValue := value, "b"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 2:
+			if actualValue, expectedValue := value, "c"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		default:
+			t.Errorf("Too many")
+		}
+	})
+}
+
+func TestMap(t *testing.T) {
+	list := New[string]()
+	list.Append("a", "b", "c")
+	mappedList := list.Map(func(index int, value string) string {
+		return "mapped: " + value
+	})
+	if actualValue, _ := mappedList.Get(0); actualValue != "mapped: a" {
+		t.Errorf("Got %v expected %v", actualValue, "mapped: a")
+	}
+	if actualValue, _ := mappedList.Get(1); actualValue != "mapped: b" {
+		t.Errorf("Got %v expected %v", actualValue, "mapped: b")
+	}
+	if actualValue, _ := mappedList.Get(2); actualValue != "mapped: c" {
+		t.Errorf("Got %v expected %v", actualValue, "mapped: c")
+	}
+	if mappedList.Size() != 3 {
+		t.Errorf("Got %v expected %v", mappedList.Size(), 3)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	list := New[string]()
+	list.Append("a", "b", "c", "d", "e")
+	values := list.Filter(func(index int, value string) bool {
+		if value == "b" || value == "d" {
+			return true
+		}
+		return false
+	})
+	assert.Equal(t, []string{"b", "d"}, values)
+	assert.Equal(t, 3, list.Size())
+	assert.Equal(t, []string{"a", "c", "e"}, list.Values())
+}
+
+func TestSwap(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	list.Swap(0, 1)
+	if actualValue, ok := list.Get(0); actualValue != "b" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "b")
+	}
+}
+
+func TestSort(t *testing.T) {
+	list := New[string]()
+	list.Sort(cmp.Compare[string])
+	list.Append("e", "f", "g", "a", "b", "c", "d")
+	list.Sort(cmp.Compare[string])
+	for i := 1; i < list.Size(); i++ {
+		a, _ := list.Get(i - 1)
+		b, _ := list.Get(i)
+		if a > b {
+			t.Errorf("Not sorted! %s > %s", a, b)
+		}
+	}
+}
+
+func TestClear(t *testing.T) {
+	list := New[string]()
+	list.Append("e", "f", "g", "a", "b", "c", "d")
+	list.Clear()
+	if actualValue := list.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := list.Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+}
+
+func TestContains(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	if actualValue := list.Contains("a"); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := list.Contains(""); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := list.Contains("a", "b", "c"); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := list.Contains("a", "b", "c", "d"); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	list.Clear()
+	if actualValue := list.Contains("a"); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := list.Contains("a", "b", "c"); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+}
+
+func TestValues(t *testing.T) {
+	list := New[string]()
+	list.Append("a")
+	list.Append("b", "c")
+	if actualValue, expectedValue := list.Values(), []string{"a", "b", "c"}; !slices.Equal(actualValue, expectedValue) {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+}
+
+func TestInsert(t *testing.T) {
+	list := New[string]()
+	list.Insert(0, "b", "c", "d")
+	list.Insert(0, "a")
+	list.Insert(10, "x") // ignore
+	if actualValue := list.Size(); actualValue != 4 {
+		t.Errorf("Got %v expected %v", actualValue, 4)
+	}
+	list.Insert(4, "g") // append
+	if actualValue := list.Size(); actualValue != 5 {
+		t.Errorf("Got %v expected %v", actualValue, 5)
+	}
+	if actualValue, expectedValue := strings.Join(list.Values(), ""), "abcdg"; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	list.Insert(4, "e", "f") // last to first traversal
+	if actualValue := list.Size(); actualValue != 7 {
+		t.Errorf("Got %v expected %v", actualValue, 7)
+	}
+	if actualValue, expectedValue := strings.Join(list.Values(), ""), "abcdefg"; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+}
+
+func TestSet(t *testing.T) {
+	list := New[string]()
+	list.Set(0, "a")
+	list.Set(1, "b")
+	if actualValue := list.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	list.Set(2, "c") // append
+	if actualValue := list.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	list.Set(4, "d")  // ignore
+	list.Set(1, "bb") // update
+	if actualValue := list.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, expectedValue := list.Values(), []string{"a", "bb", "c"}; !slices.Equal(actualValue, expectedValue) {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+}
+
+func TestString(t *testing.T) {
+	c := New[int]()
+	c.Append(1)
+	if !strings.HasPrefix(c.String(), "DoublyLinkList") {
+		t.Errorf("String should start with container name")
+	}
+}
+
+func benchmarkGet(b *testing.B, list *DoublyLinkList[int], size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			list.Get(n)
+		}
+	}
+}
+
+func benchmarkAdd(b *testing.B, list *DoublyLinkList[int], size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			list.Append(n)
+		}
+	}
+}
+
+func benchmarkRemove(b *testing.B, list *DoublyLinkList[int], size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			list.Remove(n)
+		}
+	}
+}
+
+func BenchmarkDoublyLinkedListGet100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkGet(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListGet1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkGet(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListGet10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkGet(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListGet100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkGet(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListAdd100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	list := New[int]()
+	b.StartTimer()
+	benchmarkAdd(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListAdd1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListAdd10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListAdd100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListRemove100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListRemove1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListRemove10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, list, size)
+}
+
+func BenchmarkDoublyLinkedListRemove100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	list := New[int]()
+	for n := 0; n < size; n++ {
+		list.Append(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, list, size)
+}

--- a/worker/option.go
+++ b/worker/option.go
@@ -1,0 +1,47 @@
+package worker
+
+import "time"
+
+// 协程池选项
+type Option func(*pool)
+
+// WithIdleTimeout 协程闲置超时时长，默认：60s
+func WithIdleTimeout(duration time.Duration) Option {
+	return func(p *pool) {
+		if duration > 0 {
+			p.idleTimeout = duration
+		}
+	}
+}
+
+// WithPrefill 预填充协程数量
+func WithPrefill(n int) Option {
+	return func(p *pool) {
+		if n > 0 {
+			p.prefill = n
+		}
+	}
+}
+
+// WithNonBlock 非阻塞模式，任务会被缓存到本地链表
+func WithNonBlock() Option {
+	return func(p *pool) {
+		p.nonBlock = true
+	}
+}
+
+// WithQueueCap 任务队列缓冲容量，默认无缓冲
+func WithQueueCap(cap int) Option {
+	return func(p *pool) {
+		if cap > 0 {
+			p.queueCap = cap
+		}
+	}
+}
+
+// WithPanicHandler 任务Panic处理方法
+func WithPanicHandler(fn PanicFn) Option {
+	return func(p *pool) {
+		p.panicFn = fn
+	}
+}

--- a/worker/pool.go
+++ b/worker/pool.go
@@ -1,0 +1,234 @@
+package worker
+
+import (
+	"context"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/sunmi-OS/gocore/v2/linklist"
+)
+
+const (
+	defaultPoolCap     = 10000
+	defaultIdleTimeout = 60 * time.Second
+)
+
+// Pool 协程并发复用，降低CPU和内存负载
+type Pool interface {
+	// Go 异步执行任务
+	Go(ctx context.Context, fn func(ctx context.Context))
+
+	// Close 关闭资源
+	Close()
+}
+
+// PanicFn 处理Panic方法
+type PanicFn func(ctx context.Context, err any, stack []byte)
+
+type worker struct {
+	timeUsed time.Time
+	cancel   context.CancelFunc
+}
+
+type task struct {
+	ctx context.Context
+	fn  func(ctx context.Context)
+}
+
+type pool struct {
+	input chan *task
+	queue chan *task
+	cache *linklist.DoublyLinkList[*task]
+
+	capacity int
+	workers  *linklist.DoublyLinkList[*worker]
+
+	prefill     int
+	nonBlock    bool
+	queueCap    int
+	idleTimeout time.Duration
+	panicFn     PanicFn
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewPool 生成一个新的Pool
+func NewPool(cap int, opts ...Option) Pool {
+	if cap <= 0 {
+		cap = defaultPoolCap
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	p := &pool{
+		input: make(chan *task),
+
+		capacity: cap,
+		workers:  linklist.New[*worker](),
+
+		idleTimeout: defaultIdleTimeout,
+
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	for _, fn := range opts {
+		fn(p)
+	}
+	p.queue = make(chan *task, p.queueCap)
+	// 非阻塞模式，初始化缓存链表
+	if p.nonBlock {
+		p.cache = linklist.New[*task]()
+	}
+	// 预填充
+	if p.prefill > 0 {
+		count := p.prefill
+		if p.prefill > p.capacity {
+			count = p.capacity
+		}
+		for i := 0; i < count; i++ {
+			p.spawn()
+		}
+	}
+
+	go p.run()
+	go p.idle()
+
+	return p
+}
+
+func (p *pool) Go(ctx context.Context, fn func(ctx context.Context)) {
+	p.input <- &task{ctx: ctx, fn: fn}
+}
+
+func (p *pool) Close() {
+	// 销毁协程
+	p.cancel()
+	time.Sleep(time.Second)
+	// 关闭通道
+	close(p.input)
+	close(p.queue)
+}
+
+func (p *pool) run() {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case t := <-p.input:
+			select {
+			case p.queue <- t:
+			default:
+				// 未达上限，新开一个协程
+				if p.workers.Size() < p.capacity {
+					p.spawn()
+					p.queue <- t
+					break
+				}
+				// 非阻塞模式，放入本地缓存
+				if p.nonBlock {
+					p.cache.Append(t)
+					break
+				}
+				// 阻塞模式，等待闲置协程
+				select {
+				case <-p.ctx.Done():
+					return
+				case p.queue <- t:
+				}
+			}
+		}
+	}
+}
+
+func (p *pool) idle() {
+	ticker := time.NewTicker(p.idleTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			idles := p.workers.Filter(func(index int, value *worker) bool {
+				return time.Since(value.timeUsed) > p.idleTimeout
+			})
+			for _, wk := range idles {
+				wk.cancel()
+			}
+		}
+	}
+}
+
+func (p *pool) spawn() {
+	ctx, cancel := context.WithCancel(context.TODO())
+	wk := &worker{
+		timeUsed: time.Now(),
+		cancel:   cancel,
+	}
+	// 存储协程信息
+	p.workers.Append(wk)
+
+	go func(ctx context.Context, wk *worker) {
+		var taskCtx context.Context
+		defer func() {
+			if e := recover(); e != nil {
+				if p.panicFn != nil {
+					p.panicFn(taskCtx, e, debug.Stack())
+				}
+			}
+		}()
+		for {
+			var t *task
+			// 获取任务
+			select {
+			case <-p.ctx.Done(): // Pool关闭，销毁
+				return
+			case <-ctx.Done(): // 闲置超时，销毁
+				return
+			case t = <-p.queue: // 尝试从队列获取任务
+			default:
+				// 非阻塞模式，去取缓存的任务执行
+				if p.nonBlock {
+					if v, ok := p.cache.Remove(0); ok && v != nil {
+						t = v
+						break
+					}
+				}
+				// 未取到任务，则等待新任务
+				select {
+				case <-p.ctx.Done():
+					return
+				case <-ctx.Done():
+					return
+				case t = <-p.queue:
+				}
+			}
+			// 执行任务
+			wk.timeUsed = time.Now()
+			taskCtx = t.ctx
+			t.fn(t.ctx)
+		}
+	}(ctx, wk)
+}
+
+var (
+	pp   Pool
+	once sync.Once
+)
+
+// Init 初始化默认的全局Pool
+func Init(cap int, opts ...Option) {
+	pp = NewPool(cap, opts...)
+}
+
+// P 返回默认的全局Pool
+func P() Pool {
+	if pp == nil {
+		once.Do(func() {
+			pp = NewPool(defaultPoolCap)
+		})
+	}
+	return pp
+}

--- a/worker/pool_benchmark_test.go
+++ b/worker/pool_benchmark_test.go
@@ -1,0 +1,146 @@
+package worker
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	RunTimes   = 1e6
+	PoolCap    = 5e4
+	BenchParam = 10
+)
+
+func demoFunc(ctx context.Context) {
+	time.Sleep(time.Duration(BenchParam) * time.Millisecond)
+}
+
+func BenchmarkGoroutines(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	var wg sync.WaitGroup
+	for i := 0; i < b.N; i++ {
+		wg.Add(RunTimes)
+		for j := 0; j < RunTimes; j++ {
+			go func() {
+				demoFunc(ctx)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkChannel(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	var wg sync.WaitGroup
+	sema := make(chan struct{}, PoolCap)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wg.Add(RunTimes)
+		for j := 0; j < RunTimes; j++ {
+			sema <- struct{}{}
+			go func() {
+				demoFunc(ctx)
+				<-sema
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkErrGroup(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	var wg sync.WaitGroup
+	var eg errgroup.Group
+	eg.SetLimit(PoolCap)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wg.Add(RunTimes)
+		for j := 0; j < RunTimes; j++ {
+			eg.Go(func() error {
+				demoFunc(ctx)
+				wg.Done()
+				return nil
+			})
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkWorkerPool(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	p := NewPool(PoolCap)
+	defer p.Close()
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for i := 0; i < b.N; i++ {
+		wg.Add(RunTimes)
+		for j := 0; j < RunTimes; j++ {
+			p.Go(ctx, func(ctx context.Context) {
+				demoFunc(ctx)
+				wg.Done()
+			})
+		}
+		wg.Wait()
+	}
+}
+
+func BenchmarkGoroutinesThroughput(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < RunTimes; j++ {
+			go demoFunc(ctx)
+		}
+	}
+}
+
+func BenchmarkSemaphoreThroughput(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	sema := make(chan struct{}, PoolCap)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < RunTimes; j++ {
+			sema <- struct{}{}
+			go func() {
+				demoFunc(ctx)
+				<-sema
+			}()
+		}
+	}
+}
+
+func BenchmarkWorkerPoolThroughput(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+	ctx := context.TODO()
+
+	p := NewPool(PoolCap)
+	defer p.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < RunTimes; j++ {
+			p.Go(ctx, demoFunc)
+		}
+	}
+}

--- a/worker/pool_test.go
+++ b/worker/pool_test.go
@@ -1,0 +1,87 @@
+package worker
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNormal(t *testing.T) {
+	ctx := context.Background()
+	p := NewPool(2)
+	defer p.Close()
+	m := make(map[int]int)
+	for i := 0; i < 4; i++ {
+		m[i] = i
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p.Go(ctx, func(context.Context) {
+		m[1]++
+		wg.Done()
+	})
+	wg.Add(1)
+	p.Go(ctx, func(context.Context) {
+		m[2]++
+		wg.Done()
+	})
+	wg.Wait()
+	t.Log(m)
+}
+
+func sleep1s(context.Context) {
+	time.Sleep(time.Second)
+}
+
+func TestLimit(t *testing.T) {
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	// 没有并发数限制
+	now := time.Now()
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			sleep1s(ctx)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	sec := math.Round(time.Since(now).Seconds())
+	if sec != 1 {
+		t.FailNow()
+	}
+	// 限制并发数
+	p := NewPool(2)
+	defer p.Close()
+	now = time.Now()
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		p.Go(ctx, func(ctx context.Context) {
+			sleep1s(ctx)
+			wg.Done()
+		})
+	}
+	wg.Wait()
+	sec = math.Round(time.Since(now).Seconds())
+	if sec != 2 {
+		t.FailNow()
+	}
+}
+
+func TestRecover(t *testing.T) {
+	ch := make(chan struct{})
+	defer close(ch)
+	p := NewPool(2, WithPanicHandler(func(ctx context.Context, err any, stack []byte) {
+		t.Log("[error] job panic:", err)
+		t.Log("[stack]", string(stack))
+		ch <- struct{}{}
+	}))
+	defer p.Close()
+	p.Go(context.Background(), func(ctx context.Context) {
+		sleep1s(ctx)
+		panic("oh my god!")
+	})
+	<-ch
+}


### PR DESCRIPTION
Added support for concurrent reuse of coroutines， which include `errgroup` and a thread-safe doubly linked list